### PR TITLE
feat: add transaction and view function examples

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -7,11 +7,14 @@
     "access-keys": "tsx access-keys.ts",
     "gas": "tsx gas.ts",
     "network": "tsx network.ts",
-    "view-account": "tsx view-account.ts"
+    "transactions": "tsx transactions.ts",
+    "view-account": "tsx view-account.ts",
+    "view-function": "tsx view-function.ts"
   },
   "devDependencies": {
     "@near-js/jsonrpc-client": "*",
     "@near-js/jsonrpc-types": "*",
+    "near-api-js": "^6.2.2",
     "tsx": "^4.20.3"
   }
 }

--- a/examples/transactions.ts
+++ b/examples/transactions.ts
@@ -1,7 +1,151 @@
 /**
  * Transactions Example
  *
- * This example demonstrates how to send a transaction using the NEAR JSON-RPC client.
+ * This example demonstrates how to sign and send transactions using the NEAR JSON-RPC client.
+ * It covers transaction creation, signing with a keypair, and sending signed_tx_base64 to the network.
  */
 
-// TODO: Implement this
+import {
+  createJsonRpcTransporter,
+  createRpcClient,
+} from "@near-js/jsonrpc-client";
+import { transactions, utils, KeyPairSigner } from "near-api-js";
+
+// Configuration
+const RPC_URL = "https://rpc.testnet.near.org";
+const SENDER_ACCOUNT_ID = "sender.testnet";
+const RECEIVER_ACCOUNT_ID = "receiver.testnet";
+
+// Private key - set this in your environment: export NEAR_PRIVATE_KEY="ed25519:..."
+const PRIVATE_KEY = (process.env.NEAR_PRIVATE_KEY ||
+  "ed25519:your-private-key-here") as any;
+
+/**
+ * Main transaction example: Create, sign, and send a transaction
+ */
+async function sendTransactionExample() {
+  try {
+    // 1. Create JSON-RPC client
+    const transporter = createJsonRpcTransporter({ endpoint: RPC_URL });
+    const client = createRpcClient(transporter);
+
+    // 2. Setup keypair for signing
+    const keyPair = KeyPairSigner.fromSecretKey(PRIVATE_KEY);
+    const publicKey = await keyPair.getPublicKey();
+
+    console.log(
+      `📝 Sending 0.1 NEAR from ${SENDER_ACCOUNT_ID} to ${RECEIVER_ACCOUNT_ID}\n`
+    );
+
+    // 3. Get current nonce and recent block hash
+    console.log("1️⃣ Fetching transaction requirements...");
+
+    const [accessKeyResponse, statusResponse] = await Promise.all([
+      client.query({
+        requestType: "view_access_key",
+        finality: "final",
+        accountId: SENDER_ACCOUNT_ID,
+        publicKey: publicKey.toString(),
+      }),
+      client.status({}),
+    ]);
+
+    if (accessKeyResponse.error || (accessKeyResponse.result as any)?.error) {
+      throw new Error(
+        `Access key error: ${
+          accessKeyResponse.error?.message ||
+          (accessKeyResponse.result as any)?.error
+        }`
+      );
+    }
+    if (statusResponse.error) {
+      throw new Error(`Status error: ${statusResponse.error.message}`);
+    }
+
+    const {
+      result: {
+        syncInfo: { latestBlockHash },
+      },
+    } = statusResponse;
+
+    const accessKey = accessKeyResponse.result as any;
+    const nonce = accessKey.nonce + 1;
+    const recentBlockHash = utils.serialize.base_decode(latestBlockHash);
+
+    console.log(
+      `   ✓ Nonce: ${nonce}, Block hash: ${latestBlockHash.slice(0, 10)}...`
+    );
+
+    // 4. Create and sign transaction
+    console.log("2️⃣ Creating and signing transaction...");
+
+    const actions = [
+      transactions.transfer(BigInt("100000000000000000000000")), // 0.1 NEAR
+    ];
+
+    const transaction = transactions.createTransaction(
+      SENDER_ACCOUNT_ID,
+      publicKey,
+      RECEIVER_ACCOUNT_ID,
+      nonce,
+      actions,
+      recentBlockHash
+    );
+
+    // Sign the transaction
+    const [, signedTransaction] = await keyPair.signTransaction(transaction);
+    console.log("   ✓ Transaction signed successfully");
+
+    // 5. Serialize to base64 and send via JSON-RPC client
+    console.log("3️⃣ Sending transaction to network...");
+
+    const signedTxBase64 = Buffer.from(signedTransaction.encode()).toString(
+      "base64"
+    );
+
+    const result = await client.sendTx({
+      signedTxBase64,
+      waitUntil: "FINAL",
+    });
+
+    if (result.error) {
+      console.error("❌ Transaction failed:", result.error);
+      return;
+    }
+
+    const hash = result.result.transaction.hash;
+    const gasBurnt = result.result.transactionOutcome.outcome.gasBurnt;
+
+    // 6. Display results
+    console.log("✅ Transaction successful!\n");
+    console.log("📊 Results:");
+    console.log(`   Transaction ID: ${hash}`);
+    console.log(`   Gas used: ${gasBurnt}`);
+    console.log(`   Explorer: https://testnet.nearblocks.io/txns/${hash}`);
+
+    console.log("\n💡 This example demonstrates:");
+    console.log("   • Creating transactions with near-api-js");
+    console.log("   • Signing with keypair");
+    console.log("   • Sending signed_tx_base64 via @near-js/jsonrpc-client");
+  } catch (error) {
+    console.error("❌ Error:", error.message || error);
+  }
+}
+
+/**
+ * Main function
+ */
+async function main(): Promise<void> {
+  console.log("🔗 NEAR JSON-RPC Client - Transaction Example\n");
+
+  if (PRIVATE_KEY !== "ed25519:your-private-key-here") {
+    await sendTransactionExample();
+  } else {
+    console.log(
+      "🔧 Transaction Example (SKIPPED - Set NEAR_PRIVATE_KEY to run)\n"
+    );
+  }
+}
+
+// Run the example
+main().catch(console.error);

--- a/examples/view-function.ts
+++ b/examples/view-function.ts
@@ -1,0 +1,43 @@
+/**
+ * View Function Example
+ *
+ * This example demonstrates how to call a view function on a NEAR account.
+ */
+
+import {
+  createJsonRpcTransporter,
+  createRpcClient,
+} from "@near-js/jsonrpc-client";
+
+async function main() {
+  const transporter = createJsonRpcTransporter({
+    endpoint: "https://rpc.testnet.near.org",
+  });
+  const client = createRpcClient(transporter);
+
+  console.log("🔑 NEAR JSON-RPC Client - View Function Example\n");
+
+  const { result: callFunctionResponse, error: callFunctionError } =
+    await client.query({
+      requestType: "call_function",
+      accountId: "guest-book.testnet",
+      methodName: "getMessages",
+      argsBase64: Buffer.from(JSON.stringify({})).toString("base64"),
+      finality: "final",
+    });
+
+  if (callFunctionError) {
+    console.error("Error fetching gas price:", callFunctionError);
+    return;
+  }
+
+  const { result: callFunctionResult } = callFunctionResponse as any;
+
+  console.log(
+    "View function response:",
+    JSON.parse(Buffer.from(callFunctionResult).toString()),
+    "\n"
+  );
+}
+
+main().catch(console.error);


### PR DESCRIPTION
### New Examples 
1. **`examples/transactions.ts`:** 
Added a detailed example demonstrating how to create, sign, and send transactions using `near-api-js` and the `@near-js/jsonrpc-client`. This includes fetching transaction requirements, signing with a keypair, and sending signed transactions to the network.
2. **`examples/view-function.ts`:** 
Introduced an example for calling a view function on a NEAR account, showcasing how to query contract methods using the `@near-js/jsonrpc-client`