### PR TITLE
feat: add selective methods and object-based API

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ import { jsonRpcTransporter, createClient } from "@near-js/jsonrpc-client";
 const transporter = jsonRpcTransporter({
   endpoint: "https://rpc.testnet.near.org",
 });
-const client = createClient(transporter);
+const client = createClient({ transporter });
 
 // Query account
 const account = await client.query({

--- a/examples/access-keys.ts
+++ b/examples/access-keys.ts
@@ -11,7 +11,7 @@ async function main() {
   const transporter = jsonRpcTransporter({
     endpoint: "https://rpc.testnet.near.org",
   });
-  const client = createClient(transporter);
+  const client = createClient({ transporter });
 
   console.log("🔑 NEAR JSON-RPC Client - Access Keys Example\n");
 

--- a/examples/accessing-error.ts
+++ b/examples/accessing-error.ts
@@ -10,7 +10,7 @@ async function main() {
   const transporter = jsonRpcTransporter({
     endpoint: "https://rpc.testnet.near.org",
   });
-  const client = createClient(transporter);
+  const client = createClient({ transporter });
 
   console.log("🔑 NEAR JSON-RPC Client - Access Keys Example\n");
 

--- a/examples/block.ts
+++ b/examples/block.ts
@@ -10,7 +10,7 @@ async function main() {
   const transporter = jsonRpcTransporter({
     endpoint: "https://rpc.testnet.near.org",
   });
-  const client = createClient(transporter);
+  const client = createClient({ transporter });
 
   console.log("🧱 NEAR JSON-RPC Client - Block Example\n");
 

--- a/examples/gas.ts
+++ b/examples/gas.ts
@@ -10,7 +10,7 @@ async function main() {
   const transporter = jsonRpcTransporter({
     endpoint: "https://rpc.testnet.near.org",
   });
-  const client = createClient(transporter);
+  const client = createClient({ transporter });
 
   console.log("🔑 NEAR JSON-RPC Client - Gas Price Example\n");
 

--- a/examples/network.ts
+++ b/examples/network.ts
@@ -151,7 +151,7 @@ async function main(): Promise<void> {
   const transporter = jsonRpcTransporter({
     endpoint: "https://rpc.testnet.near.org",
   });
-  const client = createClient(transporter);
+  const client = createClient({ transporter });
 
   console.log("🌐 NEAR JSON-RPC Client - Network Example\n");
 

--- a/examples/package.json
+++ b/examples/package.json
@@ -9,6 +9,7 @@
     "block": "tsx block.ts",
     "gas": "tsx gas.ts",
     "network": "tsx network.ts",
+    "selective-methods": "tsx selective-methods.ts",
     "transactions": "tsx transactions.ts",
     "validation": "tsx validation.ts",
     "view-account": "tsx view-account.ts",

--- a/examples/selective-methods.ts
+++ b/examples/selective-methods.ts
@@ -1,0 +1,57 @@
+/**
+ * Selective Methods Example
+ *
+ * This example demonstrates how to create JSON-RPC clients with only specific methods
+ * using createClientWithMethods. This reduces bundle size and creates focused clients.
+ */
+
+import {
+  createClientWithMethods,
+  jsonRpcTransporter,
+} from "@near-js/jsonrpc-client";
+import { block, status, gasPrice } from "@near-js/jsonrpc-types/methods";
+
+async function main() {
+  const transporter = jsonRpcTransporter({
+    endpoint: "https://rpc.testnet.near.org",
+  });
+
+  // Create client with only specific methods
+  const client = createClientWithMethods({
+    transporter,
+    methods: { block, status, gasPrice }, // Only these methods are available
+    runtimeValidation: true,
+  });
+
+  console.log("🎯 NEAR JSON-RPC Client - Selective Methods Example\n");
+
+  const { result: statusResult, error: statusError } = await client.status(
+    null
+  );
+
+  const { result: blockResult, error: blockError } = await client.block({
+    finality: "final",
+  });
+
+  const { result: gasPriceResult, error: gasPriceError } =
+    await client.gasPrice({});
+
+  if (statusError || blockError || gasPriceError) {
+    console.error("Error occurred:", {
+      statusError,
+      blockError,
+      gasPriceError,
+    });
+    return;
+  }
+
+  console.log("✅ Available methods:");
+  console.log(`   Status: ${statusResult.chainId}`);
+  console.log(`   Block height: ${blockResult.header.height}`);
+  console.log(`   Gas price: ${gasPriceResult.gasPrice}`);
+
+  // client.query() would cause TypeScript error - method not included!
+  console.log("\n💡 Only included methods are available (TypeScript enforced)");
+}
+
+main().catch(console.error);

--- a/examples/transactions.ts
+++ b/examples/transactions.ts
@@ -25,7 +25,7 @@ async function sendTransactionExample() {
   try {
     // 1. Create JSON-RPC client
     const transporter = jsonRpcTransporter({ endpoint: RPC_URL });
-    const client = createClient(transporter);
+    const client = createClient({ transporter });
 
     // 2. Setup keypair for signing
     const keyPair = KeyPairSigner.fromSecretKey(PRIVATE_KEY);

--- a/examples/validation.ts
+++ b/examples/validation.ts
@@ -180,7 +180,7 @@ async function main() {
   });
 
   // Create client with runtime validation enabled
-  const client = createClient(transporter, true);
+  const client = createClient({ transporter, runtimeValidation: true });
 
   console.log("🛡️ NEAR JSON-RPC Client - Type-Safe & Zod Validation Example\n");
 

--- a/examples/view-account.ts
+++ b/examples/view-account.ts
@@ -155,7 +155,7 @@ async function main(): Promise<void> {
   const transporter = jsonRpcTransporter({
     endpoint: "https://rpc.testnet.near.org",
   });
-  const client = createClient(transporter);
+  const client = createClient({ transporter });
 
   console.log("👁️  NEAR JSON-RPC Client - View Account Example\n");
 

--- a/examples/view-function.ts
+++ b/examples/view-function.ts
@@ -10,7 +10,7 @@ async function main() {
   const transporter = jsonRpcTransporter({
     endpoint: "https://rpc.testnet.near.org",
   });
-  const client = createClient(transporter);
+  const client = createClient({ transporter });
 
   console.log("🔑 NEAR JSON-RPC Client - View Function Example\n");
 

--- a/packages/jsonrpc-client/package.json
+++ b/packages/jsonrpc-client/package.json
@@ -14,9 +14,7 @@
     }
   },
   "files": [
-    "dist",
-    "src",
-    "README.md"
+    "dist"
   ],
   "scripts": {
     "build": "tsup",

--- a/packages/jsonrpc-client/src/index.ts
+++ b/packages/jsonrpc-client/src/index.ts
@@ -1,3 +1,9 @@
-export { createClient } from "./client";
+export { createClient, createClientWithMethods } from "./client";
 export { jsonRpcTransporter, NearRpcEndpoint } from "./transporter";
-export type { RpcClient, Transporter } from "./types";
+export type {
+  RpcClient,
+  Transporter,
+  SelectiveRpcClient,
+  CreateClientConfig,
+  CreateClientWithMethodsConfig,
+} from "./types";

--- a/packages/jsonrpc-client/test/integration/client.integration.test.ts
+++ b/packages/jsonrpc-client/test/integration/client.integration.test.ts
@@ -12,7 +12,7 @@ describe("NEAR JSON-RPC Client Integration", () => {
     const transporter = jsonRpcTransporter({
       endpoint: NearRpcEndpoint.Testnet,
     });
-    client = createClient(transporter);
+    client = createClient({ transporter });
   });
 
   it("should get network status", async () => {
@@ -50,10 +50,10 @@ describe("NEAR JSON-RPC Client Integration", () => {
   }, 10000);
 
   it("should handle validation errors", async () => {
-    const clientWithValidation = createClient(
-      jsonRpcTransporter({ endpoint: NearRpcEndpoint.Testnet }),
-      true
-    );
+    const clientWithValidation = createClient({
+      transporter: jsonRpcTransporter({ endpoint: NearRpcEndpoint.Testnet }),
+      runtimeValidation: true,
+    });
 
     // TODO: add test for runtime validation
     // This should pass validation

--- a/packages/jsonrpc-types/README.md
+++ b/packages/jsonrpc-types/README.md
@@ -19,6 +19,10 @@ import type {
   ValidatorStakeView,
   BlockHeaderView,
   ExecutionOutcomeView,
+  RpcBlockRequest,
+  RpcBlockResponse,
+  RpcQueryRequest,
+  RpcQueryResponse,
 } from "@near-js/jsonrpc-types";
 ```
 
@@ -31,35 +35,113 @@ import {
   status,
   validators,
   broadcastTxCommit,
+  gasPrice,
+  health,
+  networkInfo,
+  EXPERIMENTALProtocolConfig,
 } from "@near-js/jsonrpc-types/methods";
+
+// Each method provides type-safe request/response/error schemas
+const result = await client.call(query, {
+  request_type: "view_account",
+  account_id: "example.near",
+  finality: "final",
+});
 ```
 
-### Import Schemas (for validation)
+### Import TypeScript Types and Schemas
 
 ```typescript
+// TypeScript type definitions
+import type {
+  AccountView,
+  ValidatorStakeView,
+  BlockHeaderView,
+} from "@near-js/jsonrpc-types/schemas";
+```
+
+### Import Zod Validation Schemas
+
+```typescript
+// Runtime validation schemas
 import {
   AccountViewSchema,
   ValidatorStakeViewSchema,
   BlockHeaderViewSchema,
-} from "@near-js/jsonrpc-types/schemas";
+  RpcBlockRequestSchema,
+  RpcBlockResponseSchema,
+} from "@near-js/jsonrpc-types/zod-schemas";
 
-// Validate API response
+// Validate API responses at runtime
 const account = AccountViewSchema.parse(response);
+const blockRequest = RpcBlockRequestSchema.parse(userInput);
+```
+
+### Import Property Mappings
+
+```typescript
+import { mappedSnakeCamelProperty } from "@near-js/jsonrpc-types/mapped-properties";
+
+// Convert between snake_case and camelCase property names
+const camelCase = mappedSnakeCamelProperty.get("account_id"); // "accountId"
 ```
 
 ## Available Exports
 
-- **`/methods`** - JSON-RPC method definitions with type parameters
-- **`/types`** - Core TypeScript types and utility functions
-- **`/schemas`** - Runtime type definitions and Zod validation schemas
-- **`/mapped-properties`** - Property name conversion mappings
+- **`/methods`** - JSON-RPC method definitions with type parameters and validation schemas
+- **`/schemas`** - TypeScript type definitions for all NEAR JSON-RPC types
+- **`/zod-schemas`** - Runtime Zod validation schemas for type checking and parsing
+- **`/mapped-properties`** - Property name conversion mappings between snake_case and camelCase
+
+## Available Methods
+
+The package includes all NEAR JSON-RPC methods:
+
+**Core Methods:**
+
+- `block` - Get block information
+- `query` - Query account/contract state
+- `status` - Get node status
+- `validators` - Get current validators
+- `gasPrice` - Get current gas price
+- `health` - Check node health
+- `networkInfo` - Get network information
+
+**Transaction Methods:**
+
+- `broadcastTxAsync` - Broadcast transaction asynchronously
+- `broadcastTxCommit` - Broadcast transaction and wait for commit
+- `sendTx` - Send transaction
+- `tx` - Get transaction status
+
+**Advanced Methods:**
+
+- `chunk` - Get chunk information
+- `changes` - Get state changes
+- `lightClientProof` - Get light client proof
+- `nextLightClientBlock` - Get next light client block
+
+**Experimental Methods:**
+
+- `EXPERIMENTALProtocolConfig` - Get protocol configuration
+- `EXPERIMENTALValidatorsOrdered` - Get validators in order
+- `EXPERIMENTALReceipt` - Get receipt information
+- `EXPERIMENTALTxStatus` - Get transaction status
+- `EXPERIMENTALChanges` - Get state changes
+- `EXPERIMENTALChangesInBlock` - Get changes in block
+- And more...
+
+For complete method details, parameter types, and response schemas, see [`/methods`](./src/methods.ts).
 
 ## Features
 
 - Complete TypeScript coverage of NEAR JSON-RPC API
+- Runtime validation with Zod schemas
 - Tree-shakeable - import only what you need
 - Auto-generated from OpenAPI specification
-- Runtime validation with Zod schemas
+- Type-safe method definitions with request/response validation
+- Property name conversion utilities
+- Support for all NEAR JSON-RPC methods including experimental ones
 
 ## Related
 

--- a/packages/jsonrpc-types/package.json
+++ b/packages/jsonrpc-types/package.json
@@ -44,9 +44,7 @@
     "check-types": "tsc --noEmit"
   },
   "files": [
-    "dist",
-    "src",
-    "README.md"
+    "dist"
   ],
   "devDependencies": {
     "tsup": "^8.0.1",


### PR DESCRIPTION
# Overview

This PR introduces **selective methods functionality** and migrates to an **object-based API** for better developer experience and tree-shaking optimization.

## Key Changes

### **Selective Methods (`createClientWithMethods`)**
- Create focused clients with only specific JSON-RPC methods
- Reduce bundle size by excluding unused methods
- TypeScript enforces only included methods are callable
- Enable tree-shaking for optimal performance

### **Object-Based API**
- Migrate from positional to object parameters for better readability
- Self-documenting configuration objects
- Future-proof and extensible design
- Consistent API across all client creation functions

## **Changes**

### **Core Functionality**
- **feat(client)**: Add `createClientWithMethods` function
- **feat(client)**: Migrate `createClient` to object parameters
- **refactor(types)**: Eliminate type duplication with shared return type

### **Developer Experience**
- **docs(readme)**: Update API documentation with examples
- **feat(examples)**: Add selective methods usage example
- **feat(examples)**: Update all examples to use object API

## **Usage Examples**

### **Before (Positional API)**
```typescript
const client = createClient(transporter, true);
```

### **After (Object API)**
```typescript
import { block, status, gasPrice } from "@near-js/jsonrpc-types/methods";

// Full client with all methods
const client = createClient({ 
  transporter, 
  runtimeValidation: true 
});

// Selective client with specific methods
const selectiveClient = createClientWithMethods({
  transporter,
  methods: { block, status, gasPrice },
  runtimeValidation: true
});
```

## **Benefits**

- **Smaller Bundle Size**: Only include methods you need
- **Better TypeScript Support**: Enforce method availability at compile time  
- **Self-Documenting**: Clear parameter names and structure
- **Future-Proof**: Easy to add new configuration options
- **Tree-Shaking**: Import only the methods you use

## ⚠️ **Breaking Changes**

- `createClient` now accepts object parameters instead of positional parameters
- Migration is straightforward: `createClient(transporter, validation)` → `createClient({ transporter, runtimeValidation: validation })`